### PR TITLE
Use RELEASE version of cljdoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM clojure:tools-deps
 
 COPY check.sh /check.sh
 
-RUN clojure -Ttools install io.github.cljdoc/cljdoc-analyzer '{:git/tag "v1.0.695"}' :as cljdoc-analyzer
+RUN clojure -Ttools install io.github.cljdoc/cljdoc-analyzer '{:git/tag "RELEASE"}' :as cljdoc-analyzer
 
 ENTRYPOINT ["bash", "/check.sh"]


### PR DESCRIPTION
Fix #3

The risk of breaking existing builds due to changes in cljdoc is less than the value of getting improvements and bugfixes from latest cljdoc version.